### PR TITLE
close #9 バリデーション機能の追加

### DIFF
--- a/resources/pages/auth/SignIn.tsx
+++ b/resources/pages/auth/SignIn.tsx
@@ -55,6 +55,9 @@ const SigninForm = () => {
         setPassword(e.target.value);
     };
 
+    // 入力チェック
+    const validateFunc = (val: string) => !(val.length >= 6 && val.length <= 20 && val.match(/^[0-9a-zA-Z-]+$/));
+
     const handleClick = () => {
         const loginParams: LoginParams = { id, password };
         axios
@@ -87,7 +90,14 @@ const SigninForm = () => {
             <Form>
                 <Form.Group className="mb-3" controlId="formId">
                     <FloatingLabel controlId="floatingId" label="ユーザID">
-                        <Form.Control type="text" onChange={changeEmail} placeholder="ユーザID" required isInvalid />
+                        <Form.Control
+                            type="text"
+                            onChange={changeEmail}
+                            placeholder="ユーザID"
+                            required
+                            isInvalid={validateFunc(id)}
+                            autoFocus
+                        />
                     </FloatingLabel>
                 </Form.Group>
 
@@ -98,7 +108,7 @@ const SigninForm = () => {
                             onChange={changePassword}
                             placeholder="パスワード"
                             required
-                            isInvalid
+                            isInvalid={validateFunc(password)}
                         />
                     </FloatingLabel>
                 </Form.Group>

--- a/resources/pages/auth/SignUp.tsx
+++ b/resources/pages/auth/SignUp.tsx
@@ -54,6 +54,9 @@ const SignupForm = () => {
         setPassword(e.target.value);
     };
 
+    // 入力チェック
+    const validateFunc = (val: string) => !(val.length >= 6 && val.length <= 20 && val.match(/^[0-9a-zA-Z-]+$/));
+
     const handleClick = () => {
         const loginParams: LoginParams = { id, password };
         axios
@@ -77,7 +80,14 @@ const SignupForm = () => {
             <Form>
                 <Form.Group className="mb-3" controlId="formId">
                     <FloatingLabel controlId="floatingId" label="ユーザID">
-                        <Form.Control type="text" onChange={changeEmail} placeholder="ユーザID" required isInvalid />
+                        <Form.Control
+                            type="text"
+                            onChange={changeEmail}
+                            placeholder="ユーザID"
+                            required
+                            isInvalid={validateFunc(id)}
+                            autoFocus
+                        />
                     </FloatingLabel>
                 </Form.Group>
 
@@ -88,7 +98,7 @@ const SignupForm = () => {
                             onChange={changePassword}
                             placeholder="パスワード"
                             required
-                            isInvalid
+                            isInvalid={validateFunc(password)}
                         />
                     </FloatingLabel>
                 </Form.Group>


### PR DESCRIPTION
# 概要
<!-- プルリクの内容を簡単に説明（issue番号で示してもいい） -->
#9 参照
# 変更内容
<!-- プルリク前から変わる部分を書く-->
<!-- 見た目の変更がある場合はスクショによる比較などがあるとわかりやすい -->
サインイン画面・サインアップ画面のユーザIDとパスワードの入力フォームの枠の色。
「半角英数字ハイフン，6文字以上20文字以内 で入力してください」を満たす文字列を入力フォームに入れたとき、赤枠から色が変更する。

## 例
* 初期の状態
    * ![image](https://user-images.githubusercontent.com/24364250/187016812-087356f0-c7f0-4fe8-a456-e297aed2376f.png)
* 「aaaaaa」と入力したとき
    * ![image](https://user-images.githubusercontent.com/24364250/187017058-2fcc48ed-0fb7-4c2c-981a-70a1f1270eda.png)


# 検証にあたって確認してほしいこと
<!-- Reviewerに何を確認してほしいのかを具体的に書く  -->
* 「半角英数字ハイフン，6文字以上20文字以内 で入力してください」を満たす文字列を入力フォームに入れたとき、赤枠から色が変更すること
* 満たさない文字列を入力フォームに入れたとき、赤枠のままであること
# 補足
<!-- その他、注意点など -->