### PR TITLE
close #16 feather-iconsを使えるようにした

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
                 "react": "^18.2.0",
                 "react-bootstrap": "^2.4.0",
                 "react-dom": "^18.2.0",
+                "react-feather": "^2.0.10",
                 "react-router-bootstrap": "^0.26.2",
                 "react-router-dom": "^6.3.0",
                 "styled-components": "^5.3.5"
@@ -4433,6 +4434,17 @@
                 "react": "^18.2.0"
             }
         },
+        "node_modules/react-feather": {
+            "version": "2.0.10",
+            "resolved": "https://registry.npmjs.org/react-feather/-/react-feather-2.0.10.tgz",
+            "integrity": "sha512-BLhukwJ+Z92Nmdcs+EMw6dy1Z/VLiJTzEQACDUEnWMClhYnFykJCGWQx+NmwP/qQHGX/5CzQ+TGi8ofg2+HzVQ==",
+            "dependencies": {
+                "prop-types": "^15.7.2"
+            },
+            "peerDependencies": {
+                "react": ">=16.8.6"
+            }
+        },
         "node_modules/react-is": {
             "version": "16.13.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -8500,6 +8512,14 @@
             "requires": {
                 "loose-envify": "^1.1.0",
                 "scheduler": "^0.23.0"
+            }
+        },
+        "react-feather": {
+            "version": "2.0.10",
+            "resolved": "https://registry.npmjs.org/react-feather/-/react-feather-2.0.10.tgz",
+            "integrity": "sha512-BLhukwJ+Z92Nmdcs+EMw6dy1Z/VLiJTzEQACDUEnWMClhYnFykJCGWQx+NmwP/qQHGX/5CzQ+TGi8ofg2+HzVQ==",
+            "requires": {
+                "prop-types": "^15.7.2"
             }
         },
         "react-is": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
         "react": "^18.2.0",
         "react-bootstrap": "^2.4.0",
         "react-dom": "^18.2.0",
+        "react-feather": "^2.0.10",
         "react-router-bootstrap": "^0.26.2",
         "react-router-dom": "^6.3.0",
         "styled-components": "^5.3.5"

--- a/resources/pages/home/Home.tsx
+++ b/resources/pages/home/Home.tsx
@@ -3,6 +3,7 @@ import Card from 'react-bootstrap/Card';
 import Button from 'react-bootstrap/Button';
 import axios, { AxiosError } from 'axios';
 import { useNavigate } from 'react-router-dom';
+import { Heart } from 'react-feather';
 
 // styled componetnts(glid-layout用)をインポート
 import * as GridLayout from '../../css/grid_layout';
@@ -50,7 +51,10 @@ const Home = () => {
                 <div className="col-md-8">
                     <Card>
                         <Card.Body>
-                            <Card.Title>Home Component</Card.Title>
+                            <Card.Title>
+                                Home Component
+                                <Heart color="red" />
+                            </Card.Title>
                             <Card.Text>{greet}</Card.Text>
                         </Card.Body>
                         <Card.Img src="/images/composition.jpg" />


### PR DESCRIPTION
# 概要
<!-- プルリクの内容を簡単に説明（issue番号で示してもいい） -->
#16 参照

# 検証にあたって確認してほしいこと
<!-- Reviewerに何を確認してほしいのかを具体的に書く  -->
1. 事前に`sail npm install`でreact-featherをインストール
2. サンプルコードとして導入した、以下のスクショの黒丸で囲われているfeather-iconsのハートマークがちゃんと表示されていることを確認
![image](https://user-images.githubusercontent.com/24364250/191903606-83bc4ff9-548e-4443-b889-0da11a288bb1.png)

# 補足
<!-- その他、注意点など -->
#16 にも書いてあるが、使い方については[react-feather](https://github.com/feathericons/react-feather)を参照