### PR TITLE
close #22 サイドバーがスクロール時に隠れないよう変更

### DIFF
--- a/resources/layout/SideBar.tsx
+++ b/resources/layout/SideBar.tsx
@@ -11,8 +11,8 @@ const SidePanel = styled(Nav)`
     @media (min-width: 768px) {
         // md(768px)以上のとき適用
         position: sticky;
-        top: 0;
-        height: 100vh;
+        top: 87.5px; // タイトルバーの高さ
+        height: calc(100vh - 87.5px);
         z-index: 1000;
         border-right: 1px solid #ececec;
     }


### PR DESCRIPTION
# 概要
<!-- プルリクの内容を簡単に説明（issue番号で示してもいい） -->
#22 参照

* 注意
  * スクロール可能なページとスクロール可能でないページでサイドバーの幅が異なる現象が発生する
    * 原因はスクロールバーの表示の有無によって横幅が変わるためだと思われる
    * すぐさま影響のある問題ではないため、後々別のissueを立てて修正する

# 検証にあたって確認してほしいこと
<!-- Reviewerに何を確認してほしいのかを具体的に書く  -->

- [ ] スクロールしたときに次の画像のように、サイドバーが隠れないこと
  - ![image](https://user-images.githubusercontent.com/24364250/194703100-b1f193a5-2312-4fc4-9e00-60f6698ed5d5.png)
- その他の確認事項は#18 と同じ
