### PR TITLE
close #36 カスタマイズ画面の概形作る

### DIFF
--- a/resources/pages/customize/Customize.tsx
+++ b/resources/pages/customize/Customize.tsx
@@ -1,7 +1,7 @@
 /**
  * 制作者：NumLock
  * 制作日：2022/11/19
- * 更新日：
+ * 更新日：2022/11/26
  * 概要：パネルカスタマイズ画面の外枠を定義
  */
 
@@ -9,6 +9,39 @@ import React from 'react';
 import * as Cust from './css/Customize';
 import * as GridLayout from '../../css/GridLayout';
 
+// タブ部分
+const TabMenu = () => {
+    // タグクリック時の動作
+    const menuSelected = (event: React.MouseEvent) => {
+        console.log('hoge');
+        console.log(event.target);
+        // console.log(event.currentTarget);
+
+        // 何がクリックされたか判断
+        // aタグでなければ何もしない
+        // クリックされたタグに応じて中身の表示を変更
+        // select要素をつけたり外したりもする
+    };
+
+    return (
+        <Cust.Menu>
+            <h5>Customize Menu</h5>
+            <Cust.MenuUl onClick={menuSelected}>
+                <Cust.MenuLi>
+                    <Cust.MenuLiLabel>Panel</Cust.MenuLiLabel>
+                </Cust.MenuLi>
+                <Cust.MenuLi>
+                    <Cust.MenuLiLabel>Contents</Cust.MenuLiLabel>
+                </Cust.MenuLi>
+                <Cust.MenuLi>
+                    <Cust.MenuLiLabel>Preset</Cust.MenuLiLabel>
+                </Cust.MenuLi>
+            </Cust.MenuUl>
+        </Cust.Menu>
+    );
+};
+
+// カスタマイズ画面の本体？
 const Customize = () => {
     const hoge = () => {
         console.log('hoge');
@@ -48,21 +81,7 @@ const Customize = () => {
                     </GridLayout.Wrapper>
                 </Cust.Preview>
                 {/* メニュー画面 */}
-                <Cust.Menu>
-                    <h5>Customize Menu</h5>
-                    {/* 非常に見にくいので後でまとめる */}
-                    <Cust.MenuUl>
-                        <Cust.MenuLi>
-                            <Cust.MenuLiLabel>Panel</Cust.MenuLiLabel>
-                        </Cust.MenuLi>
-                        <Cust.MenuLi>
-                            <Cust.MenuLiLabel>Contents</Cust.MenuLiLabel>
-                        </Cust.MenuLi>
-                        <Cust.MenuLi>
-                            <Cust.MenuLiLabel>Preset</Cust.MenuLiLabel>
-                        </Cust.MenuLi>
-                    </Cust.MenuUl>
-                </Cust.Menu>
+                {TabMenu()}
             </Cust.CustomizeFlex>
         </>
     );

--- a/resources/pages/customize/Customize.tsx
+++ b/resources/pages/customize/Customize.tsx
@@ -6,7 +6,49 @@
  */
 
 import React from 'react';
+import * as Cust from './css/Customize';
+import * as GridLayout from '../../css/GridLayout';
 
-const Customize = () => <p>カスタマイズ画面です。</p>;
+const Customize = () => {
+    const hoge = () => {
+        console.log('hoge');
+    };
+
+    return (
+        <>
+            {hoge()}
+            {/* ここからカスタマイズ用の諸々  */}
+            {/* 横並びにするために全体をラップ */}
+            <Cust.CustomizeFlex>
+                <Cust.Preview>
+                    <h3>Now Layout</h3>
+                    {/* 「id=”container”」という親要素（div 要素）内に配置した「class=”panel_wrap”」という要素（div 要素）を整列させる処理を行う */}
+                    <GridLayout.Wrapper>
+                        <GridLayout.Container>
+                            {/* グリッドのサイズ調整用 */}
+                            <GridLayout.PanelWrap area="1 / 1" name="0" />
+                            <GridLayout.PanelWrap area="1 / 2" name="1" />
+                            <GridLayout.PanelWrap area="1 / 3" name="2" />
+                            <GridLayout.PanelWrap area="1 / 4" name="3" />
+                            <GridLayout.PanelWrap area="2 / 1" name="4" />
+                            <GridLayout.PanelWrap area="2 / 2" name="5" />
+                            <GridLayout.PanelWrap area="2 / 3" name="6" />
+                            <GridLayout.PanelWrap area="2 / 4" name="7" />
+                            <GridLayout.PanelWrap area="3 / 1" name="8" />
+                            <GridLayout.PanelWrap area="3 / 2" name="9" />
+                            <GridLayout.PanelWrap area="3 / 3" name="10" />
+                            <GridLayout.PanelWrap area="3 / 4" name="11" />
+                            <GridLayout.PanelWrap area="4 / 1" name="12" />
+                            <GridLayout.PanelWrap area="4 / 2" name="13" />
+                            <GridLayout.PanelWrap area="4 / 3" name="14" />
+                            <GridLayout.PanelWrap area="4 / 4" name="15" />
+                            {/* ここにパネルが追加される */}
+                        </GridLayout.Container>
+                    </GridLayout.Wrapper>
+                </Cust.Preview>
+            </Cust.CustomizeFlex>
+        </>
+    );
+};
 
 export default Customize;

--- a/resources/pages/customize/Customize.tsx
+++ b/resources/pages/customize/Customize.tsx
@@ -1,3 +1,10 @@
+/**
+ * 制作者：NumLock
+ * 制作日：2022/11/19
+ * 更新日：
+ * 概要：パネルカスタマイズ画面の外枠を定義
+ */
+
 import React from 'react';
 
 const Customize = () => <p>カスタマイズ画面です。</p>;

--- a/resources/pages/customize/Customize.tsx
+++ b/resources/pages/customize/Customize.tsx
@@ -1,26 +1,45 @@
 /**
  * 制作者：NumLock
  * 制作日：2022/11/19
- * 更新日：2022/11/26
+ * 更新日：2022/12/10
  * 概要：パネルカスタマイズ画面の外枠を定義
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import * as Cust from './css/Customize';
 import * as GridLayout from '../../css/GridLayout';
+import * as Contents from './components/CustomizeContents';
+import * as Panel from './components/CustomizePanel';
+import * as Preset from './components/CustomizePreset';
 
 // タブ部分
 const TabMenu = () => {
+    // 状態変数
+    const [select, setSelect] = useState('Contents');
+    const [element, setElement] = useState(Contents.Contents);
+
     // タグクリック時の動作
     const menuSelected = (event: React.MouseEvent) => {
-        console.log('hoge');
+        // console.log('hoge');
         console.log(event.target);
+        // console.log(event.target.name);
         // console.log(event.currentTarget);
 
         // 何がクリックされたか判断
         // aタグでなければ何もしない
         // クリックされたタグに応じて中身の表示を変更
         // select要素をつけたり外したりもする
+
+        setSelect('Contents');
+        // setSelect(event.target.name);
+        // 選択要素変更
+        if (select === 'Contents') {
+            setElement(Contents.Contents);
+        } else if (select === 'Panel') {
+            setElement(Panel.Panel);
+        } else if (select === 'Preset') {
+            setElement(Preset.Preset);
+        }
     };
 
     return (
@@ -28,15 +47,16 @@ const TabMenu = () => {
             <h5>Customize Menu</h5>
             <Cust.MenuUl onClick={menuSelected}>
                 <Cust.MenuLi>
-                    <Cust.MenuLiLabel>Panel</Cust.MenuLiLabel>
+                    <Cust.MenuLiLabel name="Panel">Panel</Cust.MenuLiLabel>
                 </Cust.MenuLi>
                 <Cust.MenuLi>
-                    <Cust.MenuLiLabel>Contents</Cust.MenuLiLabel>
+                    <Cust.MenuLiLabel name="Contents">Contents</Cust.MenuLiLabel>
                 </Cust.MenuLi>
                 <Cust.MenuLi>
-                    <Cust.MenuLiLabel>Preset</Cust.MenuLiLabel>
+                    <Cust.MenuLiLabel name="Preset">Preset</Cust.MenuLiLabel>
                 </Cust.MenuLi>
             </Cust.MenuUl>
+            {element}
         </Cust.Menu>
     );
 };

--- a/resources/pages/customize/Customize.tsx
+++ b/resources/pages/customize/Customize.tsx
@@ -19,10 +19,10 @@ const TabMenu = () => {
     const [element, setElement] = useState(Contents.Contents);
 
     // タグクリック時の動作
-    const menuSelected = (event: React.MouseEvent) => {
+    const menuSelected = (value: string) => {
         // console.log('hoge');
-        console.log(event.target);
-        // console.log(event.target.name);
+        // console.log(event.target);
+        // console.log(event.currentTarget);
         // console.log(event.currentTarget);
 
         // 何がクリックされたか判断
@@ -30,30 +30,38 @@ const TabMenu = () => {
         // クリックされたタグに応じて中身の表示を変更
         // select要素をつけたり外したりもする
 
-        setSelect('Contents');
-        // setSelect(event.target.name);
+        // setSelect('Contents');
+        setSelect(value); // 更新は非同期，この関数から抜けると実行?
         // 選択要素変更
-        if (select === 'Contents') {
+        if (value === 'Contents') {
             setElement(Contents.Contents);
-        } else if (select === 'Panel') {
+        } else if (value === 'Panel') {
             setElement(Panel.Panel);
-        } else if (select === 'Preset') {
+        } else if (value === 'Preset') {
             setElement(Preset.Preset);
         }
+        console.log(value);
+        // console.log(select);
     };
 
     return (
         <Cust.Menu>
             <h5>Customize Menu</h5>
-            <Cust.MenuUl onClick={menuSelected}>
-                <Cust.MenuLi>
-                    <Cust.MenuLiLabel name="Panel">Panel</Cust.MenuLiLabel>
+            <Cust.MenuUl>
+                <Cust.MenuLi onClick={() => menuSelected('Panel')}>
+                    <Cust.MenuLiLabel name="Panel" selected={select}>
+                        Panel
+                    </Cust.MenuLiLabel>
                 </Cust.MenuLi>
-                <Cust.MenuLi>
-                    <Cust.MenuLiLabel name="Contents">Contents</Cust.MenuLiLabel>
+                <Cust.MenuLi onClick={() => menuSelected('Contents')}>
+                    <Cust.MenuLiLabel name="Contents" selected={select}>
+                        Contents
+                    </Cust.MenuLiLabel>
                 </Cust.MenuLi>
-                <Cust.MenuLi>
-                    <Cust.MenuLiLabel name="Preset">Preset</Cust.MenuLiLabel>
+                <Cust.MenuLi onClick={() => menuSelected('Preset')}>
+                    <Cust.MenuLiLabel name="Preset" selected={select}>
+                        Preset
+                    </Cust.MenuLiLabel>
                 </Cust.MenuLi>
             </Cust.MenuUl>
             {element}

--- a/resources/pages/customize/Customize.tsx
+++ b/resources/pages/customize/Customize.tsx
@@ -42,10 +42,27 @@ const Customize = () => {
                             <GridLayout.PanelWrap area="4 / 2" name="13" />
                             <GridLayout.PanelWrap area="4 / 3" name="14" />
                             <GridLayout.PanelWrap area="4 / 4" name="15" />
+
                             {/* ここにパネルが追加される */}
                         </GridLayout.Container>
                     </GridLayout.Wrapper>
                 </Cust.Preview>
+                {/* メニュー画面 */}
+                <Cust.Menu>
+                    <h5>Customize Menu</h5>
+                    {/* 非常に見にくいので後でまとめる */}
+                    <Cust.MenuUl>
+                        <Cust.MenuLi>
+                            <Cust.MenuLiLabel>Panel</Cust.MenuLiLabel>
+                        </Cust.MenuLi>
+                        <Cust.MenuLi>
+                            <Cust.MenuLiLabel>Contents</Cust.MenuLiLabel>
+                        </Cust.MenuLi>
+                        <Cust.MenuLi>
+                            <Cust.MenuLiLabel>Preset</Cust.MenuLiLabel>
+                        </Cust.MenuLi>
+                    </Cust.MenuUl>
+                </Cust.Menu>
             </Cust.CustomizeFlex>
         </>
     );

--- a/resources/pages/customize/components/CustomizeContents.tsx
+++ b/resources/pages/customize/components/CustomizeContents.tsx
@@ -1,0 +1,21 @@
+/**
+ * 作成者：NumLock
+ * 作成日：2022/12/10
+ * 更新日：
+ * 概要：パネルカスタマイズ画面のcontentsタブでの動作を設定
+ */
+
+import React from 'react';
+import * as Cust from '../css/Customize';
+
+export const Contents = () => (
+    <>
+        {/* <!-- contentsタブ --> */}
+        <Cust.Contents>
+            <h6>Contents</h6>
+            <div>{/* <!-- ここにコンテンツ選択の諸々が表示される --> */}</div>
+        </Cust.Contents>
+    </>
+);
+
+export default Contents;

--- a/resources/pages/customize/components/CustomizePanel.tsx
+++ b/resources/pages/customize/components/CustomizePanel.tsx
@@ -1,0 +1,45 @@
+/**
+ * 作成者：NumLock
+ * 作成日：2022/12/10
+ * 更新日：
+ * 概要：カスタマイズ画面のパネルタブ用js．パネルの配置とかレイアウトの変更とかする
+ */
+
+import React from 'react';
+import * as Cust from '../css/Customize';
+
+export const Panel = () => (
+    <>
+        {/* <!-- panelタブ --> */}
+        <Cust.Panel>
+            <h6>Panel</h6>
+
+            {/* <!-- ここに各サイズのパネルを追加 --> */}
+            {/* <!-- パネルの種類は可変なのでjsで動的に設定する予定 --> */}
+
+            <br />
+
+            <Cust.PanelThumbnail id="panel_L" width="40%">
+                <Cust.PanelThumbnailLabel>4×4</Cust.PanelThumbnailLabel>
+                <Cust.PanelThumbnailImg src="/images/image_panel_L.jpg" name="2" />
+            </Cust.PanelThumbnail>
+
+            <Cust.PanelThumbnail id="panel_M_hol" width="40%">
+                <Cust.PanelThumbnailLabel>1×2</Cust.PanelThumbnailLabel>
+                <Cust.PanelThumbnailImg src="/images/image_panel_M_h.jpg" name="4" />
+            </Cust.PanelThumbnail>
+
+            <Cust.PanelThumbnail id="panel_M_var" width="20%">
+                <Cust.PanelThumbnailLabel>2×1</Cust.PanelThumbnailLabel>
+                <Cust.PanelThumbnailImg src="/images/image_panel_M_v.jpg" name="3" />
+            </Cust.PanelThumbnail>
+
+            <Cust.PanelThumbnail id="panel_S" width="20%">
+                <Cust.PanelThumbnailLabel>1×1</Cust.PanelThumbnailLabel>
+                <Cust.PanelThumbnailImg src="/images/image_panel_S.jpg" name="5" />
+            </Cust.PanelThumbnail>
+        </Cust.Panel>
+    </>
+);
+
+export default Panel;

--- a/resources/pages/customize/components/CustomizePreset.tsx
+++ b/resources/pages/customize/components/CustomizePreset.tsx
@@ -1,0 +1,36 @@
+/**
+ * 作成者：NumLock
+ * 作成日：2022/12/10
+ * 更新日：
+ * 概要：パネルカスタマイズ画面のpresetタブでの動作を設定
+ */
+
+import React from 'react';
+import * as Cust from '../css/Customize';
+
+export const Preset = () => (
+    <>
+        {/* <!-- presetタブ --> */}
+        <Cust.Preset>
+            <h6>Preset Layout</h6>
+
+            <Cust.PresetThumbnail id="preset01">
+                <Cust.PresetThumbnailImg src="/images/preset01.png" />
+            </Cust.PresetThumbnail>
+
+            <Cust.PresetThumbnail id="preset02">
+                <Cust.PresetThumbnailImg src="/images/preset02.png" />
+            </Cust.PresetThumbnail>
+
+            <Cust.PresetThumbnail id="preset03">
+                <Cust.PresetThumbnailImg src="/images/preset03.png" />
+            </Cust.PresetThumbnail>
+
+            <Cust.PresetThumbnail id="preset04">
+                <Cust.PresetThumbnailImg src="/images/preset04.png" />
+            </Cust.PresetThumbnail>
+        </Cust.Preset>
+    </>
+);
+
+export default Preset;

--- a/resources/pages/customize/css/Customize.ts
+++ b/resources/pages/customize/css/Customize.ts
@@ -71,6 +71,7 @@ export const MenuLiLabel = styled(MenuLi.withComponent('a'))`
     background: #eee;
     /* background: -webkit-linear-gradient(top,#444,#333); */
     /* background: -moz-linear-gradient(top,#444,#333); */
+    name: ${(props: { name: string }) => props.name};
 
     /* 縦書き */
     /* writing-mode: vertical-rl; */
@@ -101,7 +102,7 @@ export const Panel = styled.div`
 export const PanelThumbnail = styled(Panel)`
     display: flex;
     background-color: limegreen;
-    width: 40%;
+    width: ${(props: { width?: string }) => props.width};
     height: auto;
     margin: 2.5%;
 `;
@@ -112,6 +113,8 @@ export const PanelThumbnailLabel = styled(PanelThumbnail.withComponent('label'))
 export const PanelThumbnailImg = styled(PanelThumbnail.withComponent('img'))`
     /* 画像は初期値でドラッグ可能 */
     width: 100%;
+    // name設定
+    name: ${(props: { name: string }) => props.name};
 `;
 
 /* コンテンツ */

--- a/resources/pages/customize/css/Customize.ts
+++ b/resources/pages/customize/css/Customize.ts
@@ -68,11 +68,9 @@ export const MenuLiLabel = styled(MenuLi.withComponent('a'))`
     display: block;
     width: 100%;
     font-size: 14pt;
-    color: #000;
     text-decoration: none;
     padding: 7%;
     height: 100%;
-    background: #eee;
     /* background: -webkit-linear-gradient(top,#444,#333); */
     /* background: -moz-linear-gradient(top,#444,#333); */
     name: ${(props: MenuLiLabelProps) => props.name};
@@ -82,10 +80,8 @@ export const MenuLiLabel = styled(MenuLi.withComponent('a'))`
     /* text-orientation: sideways; */
     /* padding: 20%; */
 
-    &.selected {
-        background: #000;
-        color: #eee;
-    }
+    ${(props: MenuLiLabelProps) =>
+        props.name === props.selected ? 'background: #000; color: #eee;' : 'background: #eee; color: #000;'}
 `;
 
 export const MenuTab = styled(Menu)`

--- a/resources/pages/customize/css/Customize.ts
+++ b/resources/pages/customize/css/Customize.ts
@@ -47,8 +47,9 @@ export const MenuLi = styled(Menu.withComponent('li'))`
     margin-bottom: 1px;
     text-align: center;
     padding: 0px;
-    width: calc(100% / 3);
+    width: calc(100% / 3.2);
     height: 100%;
+    display: flex;
 
     /* リストを横並びに */
     float: left;
@@ -61,6 +62,7 @@ export const MenuLi = styled(Menu.withComponent('li'))`
  */
 export const MenuLiLabel = styled(MenuLi.withComponent('a'))`
     display: block;
+    width: 100%;
     font-size: 14pt;
     color: #000;
     text-decoration: none;

--- a/resources/pages/customize/css/Customize.ts
+++ b/resources/pages/customize/css/Customize.ts
@@ -60,6 +60,10 @@ export const MenuLi = styled(Menu.withComponent('li'))`
 	border-bottom: 0px;
 }
  */
+type MenuLiLabelProps = {
+    name?: string;
+    selected: string;
+};
 export const MenuLiLabel = styled(MenuLi.withComponent('a'))`
     display: block;
     width: 100%;
@@ -71,7 +75,7 @@ export const MenuLiLabel = styled(MenuLi.withComponent('a'))`
     background: #eee;
     /* background: -webkit-linear-gradient(top,#444,#333); */
     /* background: -moz-linear-gradient(top,#444,#333); */
-    name: ${(props: { name: string }) => props.name};
+    name: ${(props: MenuLiLabelProps) => props.name};
 
     /* 縦書き */
     /* writing-mode: vertical-rl; */

--- a/resources/pages/customize/css/Customize.ts
+++ b/resources/pages/customize/css/Customize.ts
@@ -19,12 +19,13 @@ export const CustomizeFlex = styled.div`
 
 export const Preview = styled(CustomizeFlex)`
     width: 60%;
+    display: block;
 `;
 
 export const Menu = styled(CustomizeFlex)`
     width: 40%;
     margin-left: 1.5%;
-    /* display: block; */
+    display: block;
 `;
 
 /* タブメニュー用のCSS */

--- a/resources/pages/customize/css/Customize.ts
+++ b/resources/pages/customize/css/Customize.ts
@@ -17,18 +17,18 @@ export const CustomizeFlex = styled.div`
     display: flex;
 `;
 
-export const Preview = styled.div`
+export const Preview = styled(CustomizeFlex)`
     width: 60%;
 `;
 
-export const Menu = styled.div`
+export const Menu = styled(CustomizeFlex)`
     width: 40%;
     margin-left: 1.5%;
     /* display: block; */
 `;
 
 /* タブメニュー用のCSS */
-export const MenuUl = styled.ul`
+export const MenuUl = styled(Menu.withComponent('ul'))`
     display: block;
     /* float: left; */
     margin: 0px;
@@ -41,7 +41,7 @@ export const MenuUl = styled.ul`
     background: #555;
 `;
 
-export const MenuLi = styled.li`
+export const MenuLi = styled(Menu.withComponent('li'))`
     border-bottom: 1px solid #000;
     margin-bottom: 1px;
     text-align: center;
@@ -58,7 +58,7 @@ export const MenuLi = styled.li`
 	border-bottom: 0px;
 }
  */
-export const MenuLiLabel = styled.a`
+export const MenuLiLabel = styled(MenuLi.withComponent('a'))`
     display: block;
     font-size: 14pt;
     color: #000;
@@ -80,7 +80,7 @@ export const MenuLiLabel = styled.a`
     }
 `;
 
-export const MenuTab = styled.div`
+export const MenuTab = styled(Menu)`
     /* display: block; */
     /* float: left; */
     background: #eee;
@@ -95,18 +95,18 @@ export const MenuTab = styled.div`
 export const Panel = styled.div`
     flex-wrap: wrap;
 `;
-export const PanelThumbnail = styled.div`
+export const PanelThumbnail = styled(Panel)`
     display: flex;
     background-color: limegreen;
     width: 40%;
     height: auto;
     margin: 2.5%;
 `;
-export const PanelThumbnailLabel = styled.div`
+export const PanelThumbnailLabel = styled(PanelThumbnail.withComponent('label'))`
     width: 200px;
     margin: 0 10% 0 0;
 `;
-export const PanelThumbnailImg = styled.img`
+export const PanelThumbnailImg = styled(PanelThumbnail.withComponent('img'))`
     /* 画像は初期値でドラッグ可能 */
     width: 100%;
 `;
@@ -122,7 +122,7 @@ export const Preset = styled.div`
     flex-wrap: wrap;
 `;
 
-export const PresetThumbnail = styled.div`
+export const PresetThumbnail = styled(Preset)`
     display: block;
     background-color: darkmagenta;
     width: 50%;
@@ -130,7 +130,7 @@ export const PresetThumbnail = styled.div`
     margin: 2.5%;
 `;
 
-export const PresetThumbnailImg = styled.img`
+export const PresetThumbnailImg = styled(PresetThumbnail.withComponent('img'))`
     width: 50%;
     height: 50%;
 `;


### PR DESCRIPTION
# 概要
<!-- プルリクの内容を簡単に説明（issue番号で示してもいい） -->
パネルカスタマイズ画面の大体の形を作った
右側のタブメニュー部分まで

# 変更内容
<!-- プルリク前から変わる部分を書く-->
<!-- 見た目の変更がある場合はスクショによる比較などがあるとわかりやすい -->
カスタマイズ画面にいろいろ追加される

変更前
![image](https://user-images.githubusercontent.com/71932961/211135474-69f1d21c-8254-41e9-90d9-add9ad549351.png)

変更後
![image](https://user-images.githubusercontent.com/71932961/211135508-e7c99801-6006-46d0-b159-9a1d8463e5d6.png)



# 検証にあたって確認してほしいこと
<!-- Reviewerに何を確認してほしいのかを具体的に書く  -->

- [x] タブクリックで直ちに内容が変わること
- [x] タブと内容がちゃんと対応していること(対応についてはタブのすぐ下に「Contents」とか出るからそれがあってればいい)
- [x] 中央に grid layout の領域が確保されていること(ちゃんと4×4の正方形の領域かどうかも確認)

# 補足
<!-- その他、注意点など -->